### PR TITLE
I revised how post-rejection correction is done.

### DIFF
--- a/src/calmod.r
+++ b/src/calmod.r
@@ -53,9 +53,13 @@ calmod <- function(target,x,sumstat,tol,gwt,rejmethod=T)
   
   # wt1 defines the region we're interested in 
   abstol <- quantile(dst,tol)
-  # making sure all simulated results are included when tol = 1.
-  if(tol == 1) {abstol <- abstol * 1.1}
-  wt1 <- dst < abstol
+  # making sure all simulated results are included when tol = 1.    
+  if (tol == 1) {
+    wt1 <- rep(T,length(dst))
+  } else {
+    wt1 <- dst < abstol    
+  }
+
   nit <- sum(wt1)
   
   if(rejmethod){

--- a/src/loc2plot.r
+++ b/src/loc2plot.r
@@ -2,9 +2,9 @@ loc2plot <- function(x,y,cprob=0.5,alpha=0.5,xlim,gxlim,...)
 {
         sc1 <- sqrt(var(x))
         sc2 <- sqrt(var(y))
-        if(missing(xlim)) fit <- locfit(~x+y,alpha=alpha,scale=c(sc1,sc2),
+        if(missing(xlim)) fit <- locfit(~lp(x+y,nn=alpha,scale=c(sc1,sc2)),
         maxk=100,mint=100,cut=0.8,maxit=100)
-        else fit <- locfit(~x+y,alpha=alpha,scale=c(sc1,sc2),
+        else fit <- locfit(~lp(x+y,nn=alpha,scale=c(sc1,sc2)),
         xlim=xlim,maxk=100,mint=100,cut=0.8,maxit=100)
         lev <- sort(fitted(fit))[floor(cprob*length(x))]
         plot(fit,lev=lev,m=100,label=paste(as.character(100*(1-cprob)),"%",sep=""),
@@ -16,10 +16,10 @@ loc2plotw <- function(x,y,cprob=0.5,alpha=0.5,xlim,gxlim,wt,...)
 {
         sc1 <- sqrt(var(x))
         sc2 <- sqrt(var(y))
-        if(missing(xlim)) fit <- locfit(~x+y,alpha=alpha,scale=c(sc1,sc2),
-        maxk=100,mint=100,cut=0.8,maxit=100,weight=wt)
-        else fit <- locfit(~x+y,alpha=alpha,scale=c(sc1,sc2),
-        xlim=xlim,maxk=100,mint=100,cut=0.8,maxit=100,weight=wt)
+        if(missing(xlim)) fit <- locfit(~lp(x+y,nn=alpha,scale=c(sc1,sc2)),
+        maxk=100,mint=100,cut=0.8,maxit=100,weights=wt)
+        else fit <- locfit(~lp(x+y,nn=alpha,scale=c(sc1,sc2)),
+        xlim=xlim,maxk=100,mint=100,cut=0.8,maxit=100,weights=wt)
         lev <- sort(fitted(fit))[floor(cprob*length(x))]
         plot(fit,lev=lev,m=100,label=paste(as.character(100*(1-cprob)),"%",sep=""),
         xlim=gxlim,...)
@@ -29,9 +29,9 @@ gethpdprob2 <- function(x,y,px,py,alpha=0.5,xlim,gxlim,...)
 {
         sc1 <- sqrt(var(x))
         sc2 <- sqrt(var(y))
-        if(missing(xlim)) fit <- locfit(~x+y,alpha=alpha,scale=c(sc1,sc2),
+        if(missing(xlim)) fit <- locfit(~lp(x+y,nn=alpha,scale=c(sc1,sc2)),
         maxk=100,mint=100,cut=0.8,maxit=100)
-        else fit <- locfit(~x+y,alpha=alpha,scale=c(sc1,sc2),
+        else fit <- locfit(~lp(x+y,nn=alpha,scale=c(sc1,sc2)),
         xlim=xlim,maxk=100,mint=100,cut=0.8,maxit=100)
 #       d1 <- (x-px)^2+(y-py)^2
 #       best <- d1 == min(d1)
@@ -49,9 +49,9 @@ loc2mode <- function(x,y,alpha=0.5,xlim,...)
 {
         sc1 <- sqrt(var(x))
         sc2 <- sqrt(var(y))
-        if(missing(xlim)) fit <- locfit(~x+y,alpha=alpha,scale=c(sc1,sc2),
+        if(missing(xlim)) fit <- locfit(~lp(x+y,alpha=alpha,scale=c(sc1,sc2)),
         maxk=100,mint=100,cut=0.8,maxit=100)
-        else fit <- locfit(~x+y,alpha=alpha,scale=c(sc1,sc2),
+        else fit <- locfit(~lp(x+y,nn=alpha,scale=c(sc1,sc2)),
         xlim=xlim,maxk=100,mint=100,cut=0.8,maxit=100)
         tt <- max(fitted(fit))
         wt <- fitted(fit) == tt
@@ -61,8 +61,8 @@ loc2mode <- function(x,y,alpha=0.5,xlim,...)
 
 loc1stats <- function(x,prob=0.95,alpha=0.5,xlim,...)
 {
-        if(missing(xlim)) fit <- locfit(~x,alpha=alpha)
-        else fit <- locfit(~x,alpha=alpha,xlim=xlim)
+        if(missing(xlim)) fit <- locfit(~lp(x,nn=alpha))
+        else fit <- locfit(~lp(x,nn=alpha),xlim=xlim)
         fx <- fitted(fit)
         x.modef <- max(fx)
         x.mode <- x[fx == x.modef]
@@ -99,8 +99,8 @@ tloc2plot <- function(x,y,cprob=0.5,alpha=0.5,xlim,gxlim,...)
 {
         sc1 <- sqrt(var(x))
         sc2 <- sqrt(var(y))
-        if(missing(xlim)) fit <- locfit(~x+y,alpha=alpha)
-        else fit <- locfit(~x+y,alpha=alpha,
+        if(missing(xlim)) fit <- locfit(~lp(x+y,nn=alpha))
+        else fit <- locfit(~lp(x+y,nn=alpha),
         xlim=xlim)
         lev <- sort(fitted(fit))[floor(cprob*length(x))]
         plot(fit,lev=lev,m=100,label=paste(as.character(100*(1-cprob)),"%",sep=""),

--- a/src/make_pd2005.r
+++ b/src/make_pd2005.r
@@ -51,8 +51,11 @@ nss <- length(sumstat[1,])
 # wt1 defines the region we're interested in 
     abstol <- quantile(dst,tol)
 # making sure all simulated results are included when tol = 1.
-    if(tol == 1) {abstol <- abstol * 1.1}
-    wt1 <- dst < abstol
+    if (tol == 1) {
+      wt1 <- rep(T,length(dst))
+    } else {
+      wt1 <- dst < abstol
+    }
 
     if(rejmethod){
         l1 <- list(x=x[wt1],wt=0)

--- a/src/pods_post.r
+++ b/src/pods_post.r
@@ -38,7 +38,7 @@ Z1true1<- OBS[1,2]
 # Original R script used 'rejection' but in the paper it says to use 'neuralnet'
 #Z1noLL6 <- try(abc(OBS[1,c(42:95,114:131)], POSTVEC[,2], POSTVEC[,c(42:95,114:131)], tol=0.1,method="rejection"),T)
 Z1noLL6 <- try(abc(OBS[1,c(42:95,114:131)], POSTVEC[,2], POSTVEC[,c(42:95,114:131)], tol=0.1,method="neuralnet"),T)
-if(class(Z1noLL6) == "try-error"){
+if(inherits(Z1noLL6, "try-error")){
 	TDnoLLRmode6 <- NA
 	rmspe6<-NA
 } else { 
@@ -76,7 +76,7 @@ under
 # Original method was 'loclinear', but it fsck on small data?
 #Z1noLL8 <- try(abc(OBS[1,c(42:95,114:131)], POSTVEC[,5], POSTVEC[,c(42:95,114:131)], tol=0.1,method="neuralnet"),T)
 Z1noLL8 <- try(abc(OBS[1,c(42:95,114:131)], POSTVEC[,5], POSTVEC[,c(42:95,114:131)], tol=0.1,method="loclinear"),T)
-if(class(Z1noLL8) == "try-error"){
+if(inherits(Z1noLL8, "try-error")){
 	TDnoLLRmode8 <- NA
 	rmspe8<-NA
 

--- a/src/rejectinC.c
+++ b/src/rejectinC.c
@@ -207,7 +207,7 @@ main (int argc, char *argv[])
 
   if (oldTol != tolerance) {
     
-    double betterTol = 500.0 / (double) linecount;
+    double betterTol = 1000.0 / (double) linecount;
     fprintf(stderr, "ERROR: No memory in msReject.\n");
     fprintf(stderr, 
 	    "ERROR: PLEASE USE A LOWER TOLERANCE. Instead of %f you "
@@ -217,7 +217,7 @@ main (int argc, char *argv[])
 	     betterTol, tolerance);
     fprintf (stderr,     
 	     "ERROR: The lowest tolerance (%g) results in acceptance of "
-	     "500 simulations.\n",
+	     "1000 simulations.\n",
 	     betterTol);
     fprintf(stderr,
 	    "ERROR: A low tolerance value, accepting 500-1000 simulations, is\n"


### PR DESCRIPTION
- For the discrete variable (Psi), we aren't using multinominal
  regression with calmod any more since here are too many parameters
  to estimate during the regression.  The code is still there, but the
  users won't see the option to use calmod.
- acceptRej.pl used to accept best 500 simulations, but now it is
  increased to 1000.
- If tolerance is set too low for post-rejection correction with
  regression, it uses simple rejection method to construct posterior
  distribution.

Miner bug fix.
- In calmod.r and make_pd2005.r, I fixed the problem where abstol was
  set incorrectly with tol=1.

Removed warnings with newer versions of R.
- In R, behavior of try() changed, so we updated how error is handled.
- locfit() in R uses slightly different formula specification with
  lp(). I updated the deprecated options in loc2plot.r.